### PR TITLE
updates to make sensors > position 6 generic

### DIFF
--- a/Firmware/SaratogaSIS.ino
+++ b/Firmware/SaratogaSIS.ino
@@ -354,6 +354,10 @@ void loop()
             if (i <= MAX_DOOR) {
             	processDoorSensor(i);
         	  }
+            else
+            {
+              processSensor(i);
+            }
           }
 
            	// code to blink the D7 LED when a sensor trip is detected
@@ -621,6 +625,24 @@ void processDoorSensor(int sensorIndex)
 
 }
 /***********************************end of processDoorSensor() ****************************************/
+
+/********************************** processSensor() *****************************************/
+// processSensor():  function to process a generic sensor trip.  This function creates a
+//  log entry for each registered sensor trip and records the log entry in the circular buffer.
+//
+//  Arguments:
+//  	sensorIndex: the index into the sensorName[] and activateCode[] arrays for the sensor
+//       	to be logged.
+
+void processSensor(int sensorIndex)
+{
+
+	logSensor(sensorIndex);
+
+	return;
+
+}
+/***********************************end of processSensor() ****************************************/
 
 /******************************************** writeConfig() ******************************************/
 // writeConfig():  writes the sensor configuration out to non-volatile memory using the Wire library

--- a/Firmware/SaratogaSIS.ino
+++ b/Firmware/SaratogaSIS.ino
@@ -23,7 +23,7 @@
 // Version 08b:  included #ifdef and #incude temporary fix for I2C library issue on Photon.
 //  Uncommented Wire.setSpeed() with this fix.
 //
-// Version 08a:  had to comment out line 215: Wire.setSpeed(CLOCK_SPEED_100KHZ); and line 374: 
+// Version 08a:  had to comment out line 215: Wire.setSpeed(CLOCK_SPEED_100KHZ); and line 374:
 //  Spark.SyncTime(); in order to get the code to compile for Photon.  It compiles OK for Core.
 //  Also had to change the varible name "registrationInfo" to "registration" (line 253) and
 //  "circularBufferReadout" to "circularBuff" (line 252) and now these variables are accessible by SIS
@@ -38,7 +38,7 @@
 // Version 6a -- version 6 caused each of my two test cores to reset, at very different times.  This
 //  was even though I could not cause a reset by power cycling my cable modem.  This version reduces
 //  the buffer size to 25, does not publish each sensor trip, but publishes recorded events.  This
-//  version is for robustness testing of a possible operational scenario where the main logging 
+//  version is for robustness testing of a possible operational scenario where the main logging
 //  is via publication to the cloud with a small local buffer as a backup.
 //
 // Version 6 - put in changes requested by Jim to baseline version 5:
@@ -47,7 +47,7 @@
 //      re-establish the time when movement is again detected.
 //  - retain the ability, based upon #define, to publish to the cloud each of the following: trip,
 //      event, and advisory.
-//  - change the return value of register() to be -1 for any failure (memo - was already there - 
+//  - change the return value of register() to be -1 for any failure (memo - was already there -
 //      no change required.
 //
 // Version 5 - increase buffer size to 50 (then reduced to 40) for testing Core resets.
@@ -99,11 +99,12 @@ const int INTERRUPT_433 = 4;   // the 433 MHz receiver is attached to interrupt 
 const int WINDOW = 200;    	// timing window (+/- microseconds) within which to accept a bit as a valid code
 const int TOLERANCE = 60;  	// % timing tolerance on HIGH or LOW values for codes
 const unsigned long ONE_DAY_IN_MILLIS = 86400000L;	// 24*60*60*1000
-const int MAX_WIRELESS_SENSORS = 10;
+const int MAX_WIRELESS_SENSORS = 15;
 const unsigned long FILTER_TIME = 5000L;  // Once a sensor trip has been detected, it requires 5 seconds before a new detection is valid
 const int BUF_LEN = 25;     	// circular buffer size.
 const int MAX_PIR = 4;      	// PIR sensors are registered in loc 0 through MAX_PIR.  Locations MAX_PIR + 1 to
                             	//  BUF_LEN are non-PIR sensors
+const int MAX_DOOR = 6;       // Sensors > MAX_PIR and <= MAX_DOOR are assumed to be exit doors.
 const int MAX_SUBSTRINGS = 6;   // the largest number of comma delimited substrings in a command string
 const byte NUM_BLINKS = 2;  	// number of times to blink the D7 LED when a sensor trip is received
 const unsigned long BLINK_TIME = 300L; // number of milliseconds to turn D7 LED on and off for a blink
@@ -154,7 +155,13 @@ String sensorName[] =      	{ "FrontRoom PIR",
                              	"GarageDoor Sep",
                              	"UNREGISTERED S7",
                              	"UNREGISTERED S8",
-                             	"UNREGISTERED S9"
+                             	"UNREGISTERED S9",
+                             	"UNREGISTERED S10",
+                             	"UNREGISTERED S11",
+                             	"UNREGISTERED S12",
+                             	"UNREGISTERED S13",
+                             	"UNREGISTERED S14",
+                             	"UNREGISTERED S15"
                            	};
 
 unsigned long activateCode[] = { 86101,   // sensor 0 (door/window) activation code
@@ -166,7 +173,12 @@ unsigned long activateCode[] = { 86101,   // sensor 0 (door/window) activation c
                              	12899438,   // sensor 6 (water level sensor) activation code
                              	0,      	// UNREGISTERED SENSOR
                              	0,      	// UNREGISTERED SENSOR
-                             	0       	// UNREGISTERED SENSOR
+                             	0,      	// UNREGISTERED SENSOR
+                             	0,      	// UNREGISTERED SENSOR
+                             	0,      	// UNREGISTERED SENSOR
+                             	0,      	// UNREGISTERED SENSOR
+                             	0,      	// UNREGISTERED SENSOR
+                             	0,      	// UNREGISTERED SENSOR
                            	};
 
 unsigned long lastTripTime[MAX_WIRELESS_SENSORS];	// array to hold the last time a sensor was tripped - for filtering purposes
@@ -273,7 +285,7 @@ void setup()
   	lastTripTime[i] = 0L;
   }
 
- 
+
   digitalWrite(D7, LOW);
 
 }
@@ -339,8 +351,10 @@ void loop()
         	}
         	else                	// not a PIR, then a door sensor
         	{
+            if (i <= MAX_DOOR) {
             	processDoorSensor(i);
-        	}
+        	  }
+          }
 
            	// code to blink the D7 LED when a sensor trip is detected
         	if(blinkReady)
@@ -464,7 +478,7 @@ void logMessage(int messageIndex)
         readFromBuffer(0, localBuf);      // read out the latest logged entry into the "cloudBuf" variable
         Spark.publish("LogEntry", localBuf);  // ... and publish it to the cloud for xteranl logging
     #endif
-    
+
 	return;
 }
 
@@ -514,13 +528,13 @@ void logSensor(int sensorIndex)
 	}
 
 	cBufInsert("" + logEntry);
-	
+
 	#ifdef CLOUD_LOG
         char localBuf[90];
         readFromBuffer(0, localBuf);      // read out the latest logged entry into the "cloudBuf" variable
         Spark.publish("LogEntry", localBuf);  // ... and publish it to the cloud for xteranl logging
     #endif
-    
+
 	return;
 }
 
@@ -572,10 +586,10 @@ void processPIRSensor(int sensorIndex)
     	logSensor(sensorIndex);
     	comatose = false;   // any PIR resets comatose flag
 	}
-    
+
     // any PIR trip indicates that person is moving
-    lastPIRTime = Time.now();  
-    
+    lastPIRTime = Time.now();
+
     // update globals for PIR trip detection
     lastSensorIsDoor = false;
 
@@ -1042,7 +1056,7 @@ int registrar(String action)
         	break;
 
     	default:
-            numSubstrings = -1; // return an error code for unknown command       	
+            numSubstrings = -1; // return an error code for unknown command
         	break;
 	}
 
@@ -1067,17 +1081,17 @@ int readBuffer(String location)
 {
     int offset;
     int result;
-    
+
     offset = location.toInt();
     result = readFromBuffer(offset, cloudBuf);
-    
+
     return result;
 }
 
 /*********************************end of readBuffer() *****************************************/
 
 /********************************** readFromBuffer() ******************************************/
-// readFromBuffer(): utility fujction to read from the circular buffer into the designated 
+// readFromBuffer(): utility fujction to read from the circular buffer into the designated
 //  character array.
 //  Arguments:
 //      int offset: the offset into the circular buffer to read from. 0 is the latest entry.  The

--- a/website/jbsSpark.js
+++ b/website/jbsSpark.js
@@ -106,7 +106,14 @@ SHRIMPWARE.SISTest = (function() { // private module variables
         ElmStreet: [
             {pos: 0, label: "FrontRoomPIR",  display: "Front Room PIR"},
             {pos: 1, label: "JimsRoomPIR",   display: "Jim's Office PIR"},
-            {pos: 6, label: "FrontDoorSep",  display: "Front Door Separation"}
+            {pos: 2, label: "KitchenPIR",   display: "Kitchen PIR"},
+            {pos: 3, label: "MasterBRPIR",   display: "MasterBR PIR"},
+            {pos: 4, label: "LivingroomPIR",   display: "Livingroom PIR"},
+            {pos: 5, label: "FrontDoorSep",  display: "Front Door Separation"},
+            {pos: 6, label: "BackDoorSep",  display: "Back Door Separation"},
+            {pos: 8, label: "OnePersonHome",  display: "One Person Home"},
+            {pos: 9, label: "TwoPeopleHome",  display: "Two People Home"},
+            {pos: 10, label: "NoOneHome",  display: "No One Home"}
         ]
     }
 
@@ -867,10 +874,10 @@ SHRIMPWARE.SISTest = (function() { // private module variables
 
     },
     clearSensorConfig = function() {
-        for (var i=0; i<10; i++) {
-            var commandParam = "register," + i + "," + i + ",cleared";
+        for (var i=0; i<15; i++) {
+            var commandParam = "register," + i + "," + i + ",unknown";
             logAdd(commandParam);
-            callSparkCoreFunction("Register",commandParam, function(data) {
+            callSparkCoreFunction("Register",commandParam, function(i) {
                 logAdd("Sensor Config position cleared:" + i);
             }
         )}

--- a/website/readme.txt
+++ b/website/readme.txt
@@ -1,3 +1,5 @@
 This folder holds the Javascript based web site.
 
 
+
+


### PR DESCRIPTION
I needed to have some sensors for the one-home, two-home, noOne-home indicators. I didn't want these to be treated a door-open events. I added a new global MAX_DOOR. Any sensors in configuration positions between MAX_PIR and <= MAX_DOOR are treated as door sensors. If they are above MAX_DOOR then they are treated as a generic sensor.

Also updated the web site javascript to have more sensors in Elm Street.
